### PR TITLE
fix repl freezing when typing C-<arrows>

### DIFF
--- a/command-functions.lisp
+++ b/command-functions.lisp
@@ -90,6 +90,10 @@
     (add-char #\) editor)
     (decf (get-point editor))))
 
+(defun clear-screen (chord editor)
+  (declare (ignore chord))
+  (terminal-clear-screen))
+
 ;;; CASE CHANGES
 
 (flet ((frob-case (frob editor)

--- a/command-functions.lisp
+++ b/command-functions.lisp
@@ -80,6 +80,16 @@
   (declare (ignore chord editor))
   (throw 'linedit-done t))
 
+(defun new-sexp (chord editor)
+  (declare (ignore chord editor))
+  (with-editor-point-and-string ((point string) editor)
+    (move-to-eol chord editor)
+    (add-char #\( editor)
+    (incf (get-point editor))
+    (move-to-eol chord editor)
+    (add-char #\) editor)
+    (decf (get-point editor))))
+
 ;;; CASE CHANGES
 
 (flet ((frob-case (frob editor)

--- a/command-keys.lisp
+++ b/command-keys.lisp
@@ -36,7 +36,7 @@
 (defcommand "C-G")
 (defcommand "C-J")
 (defcommand "C-K" 'kill-to-eol)
-(defcommand "C-L")
+(defcommand "C-L" 'clear-screen)
 (defcommand "C-N" 'history-next)
 (defcommand "C-O" 'close-all-sexp)
 (defcommand "C-P" 'history-previous)

--- a/command-keys.lisp
+++ b/command-keys.lisp
@@ -65,7 +65,7 @@
 (defcommand "M-K")
 (defcommand "M-L" 'downcase-word)
 (defcommand "M-M")
-(defcommand "M-N")
+(defcommand "M-N" 'new-sexp)
 (defcommand "M-O")
 (defcommand "M-P")
 (defcommand "M-Q")

--- a/command-keys.lisp
+++ b/command-keys.lisp
@@ -113,3 +113,6 @@
 (defcommand "Page-down")
 (defcommand "Home" 'move-to-bol)
 (defcommand "End" 'move-to-eol)
+
+(defcommand "C-Right-arrow" 'forward-sexp)
+(defcommand "C-Left-arrow" 'backward-sexp)

--- a/smart-terminal.lisp
+++ b/smart-terminal.lisp
@@ -41,6 +41,9 @@
        (or ti:column-address (and ti:cursor-left ti:cursor-right))
        (or ti:auto-right-margin ti:enter-am-mode)))
 
+(defun terminal-clear-screen ()
+     (ti:tputs ti:clear-screen))
+
 (defmethod backend-init ((backend smart-terminal))
   (call-next-method)
   (when ti:enter-am-mode

--- a/smart-terminal.lisp
+++ b/smart-terminal.lisp
@@ -42,7 +42,8 @@
        (or ti:auto-right-margin ti:enter-am-mode)))
 
 (defun terminal-clear-screen ()
-     (ti:tputs ti:clear-screen))
+  (when ti:clear-screen
+    (format t "~A~A" ti:clear-screen (editor-prompt *editor*))))
 
 (defmethod backend-init ((backend smart-terminal))
   (call-next-method)

--- a/terminal-translations.lisp
+++ b/terminal-translations.lisp
@@ -112,3 +112,6 @@
 (deftrans "Page-down"   (#\Esc #\[ #\6 #\~))
 (deftrans "Home"        (#\Esc #\[ #\7 #\~) (#\Esc #\[ #\1 #\~) (#\Esc #\[ #\H))
 (deftrans "End"         (#\Esc #\[ #\8 #\~) (#\Esc #\[ #\4 #\~) (#\Esc #\[ #\F))
+
+(deftrans "C-Right-arrow" (#\Esc #\[ #\1 #\; #\5 #\C))
+(deftrans "C-Left-arrow"  (#\Esc #\[ #\1 #\; #\5 #\D))

--- a/terminal.lisp
+++ b/terminal.lisp
@@ -51,8 +51,21 @@
   (flet ((read-open-chord ()
 	   (do ((chars nil)
 		(c #1=(read-char) #1#))
-	       ((member c '(#\- #\~ #\$)) (nconc (nreverse chars) (list c)))
-	     (push c chars))))
+	       ((or (member c '(#\- #\~ #\$))
+                    (if (char-equal c #\;)
+                        (let ((c1 (read-char))
+                              (c2 (read-char)))
+                          (push #\; chars)
+                          (push c1 chars)
+                          (push c2 chars)
+                          ;; (format t "add (~A,~A,~A): chars:~A~%"
+                          ;; 	c c1 c2 chars)
+                          t)))
+                (nconc (nreverse chars)
+                       (if (char-not-equal c #\;)
+                           (list c))))
+	     (when (char-not-equal c #\;)
+	       (push c chars)))))
     (let ((chord
 	   (acase (read-char)
 	     (#\Esc
@@ -63,7 +76,8 @@
 				 (if (digit-char-p char)
 				     (cons char
 					   (read-open-chord))
-				     (list char)))))
+                                     (when (char-not-equal char #\;)
+				       (list char))))))
 			 (t (list it)))))
 	     (t (if (graphic-char-p it)
 		    it


### PR DESCRIPTION
I made some changes to solve the problem of repl freezing when typing Ctrl-right/left arrow. I'm used to these key bindings in emacs and muscle memory makes linedit unusable for me, since the terminal suddenly becomes unresponsive.
I bound C-right to forward-sexp and C-left to backward-sexp.
I also added the clear-screen (screen refresh as in emacs) command (bound to C-l)
and new-sexp (bound to M-N)