### PR TITLE
new command: inspect-word

### DIFF
--- a/command-functions.lisp
+++ b/command-functions.lisp
@@ -356,6 +356,11 @@
                   (with-output-to-string (s)
                     (describe (read-from-string (editor-word editor)) s))))
 
+(defun inspect-word (chord editor)
+  (declare (ignore chord))
+  (without-backend editor
+    (inspect (read-from-string (editor-word editor)))))
+
 (defun toggle-insert (chord editor)
   (declare (ignore chord))
   (setf (editor-insert-mode editor) (not (editor-insert-mode editor))))

--- a/command-keys.lisp
+++ b/command-keys.lisp
@@ -61,7 +61,7 @@
 (defcommand "M-G")
 (defcommand "M-H" 'help)
 (defcommand "M-I" 'describe-word)
-(defcommand "M-J")
+(defcommand "M-J" 'inspect-word)
 (defcommand "M-K")
 (defcommand "M-L" 'downcase-word)
 (defcommand "M-M")


### PR DESCRIPTION
bound to 'M-J' - seems to work well enough, but completion is broken when returning from the inspector until the next command.